### PR TITLE
Fix sound function duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <title>Weltgenerator</title>
   <link rel="stylesheet" href="./common.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-  <script src="./worldData.js"></script>
   <script src="./common.js"></script>
+  <script src="./worldData.js"></script>
   <style>
     /* Spielmodus: Raster als CSS-Grid */
     #gameOutput {

--- a/worldData.js
+++ b/worldData.js
@@ -256,28 +256,3 @@ const worldData = {
   }
 };
 
-function playPewSound() {
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  const oscillator = ctx.createOscillator();
-  const gain = ctx.createGain();
-  oscillator.type = "square";
-  oscillator.frequency.setValueAtTime(440, ctx.currentTime);
-  oscillator.connect(gain);
-  gain.connect(ctx.destination);
-  oscillator.start();
-  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.2);
-  oscillator.stop(ctx.currentTime + 0.2);
-}
-
-function playPowSound() {
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  const oscillator = ctx.createOscillator();
-  const gain = ctx.createGain();
-  oscillator.type = "sawtooth";
-  oscillator.frequency.setValueAtTime(200, ctx.currentTime);
-  oscillator.connect(gain);
-  gain.connect(ctx.destination);
-  oscillator.start();
-  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.2);
-  oscillator.stop(ctx.currentTime + 0.2);
-}


### PR DESCRIPTION
## Summary
- remove duplicate sound helpers from `worldData.js`
- ensure `common.js` loads before `worldData.js`

## Testing
- `node - <<'EOF'
const fs = require('fs');
const vm = require('vm');
const context = {
  window: {
    AudioContext: function(){ this.createOscillator=()=>({connect:()=>{},start:()=>{},frequency:{setValueAtTime:()=>{}},stop:()=>{}}); this.createGain=()=>({connect:()=>{},gain:{exponentialRampToValueAtTime:()=>{}}}); },
    webkitAudioContext: function(){ this.createOscillator=()=>({connect:()=>{},start:()=>{},frequency:{setValueAtTime:()=>{}},stop:()=>{}}); this.createGain=()=>({connect:()=>{},gain:{exponentialRampToValueAtTime:()=>{}}}); }
  }
};
vm.createContext(context);
vm.runInContext(fs.readFileSync('common.js','utf8'), context);
context.playPewSound();
context.playPowSound();
console.log('functions executed');
EOF