### PR TITLE
Reset grid after win

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,8 +156,30 @@ function movePlayer(dx,dy) {
   if (cell===' '||cell===target) {
     if (cell===target) { playPewSound(); foundCount++; document.getElementById('foundCount').innerText=`Gefundene Ziele: ${foundCount}`; }
     gameGrid[playerY][playerX] = ' '; gameGrid[ny][nx] = w.player; playerX=nx; playerY=ny; renderGame();
-    if (foundCount>=initialTargets) { clearInterval(timerInterval); alert(`Spiel beendet!\nGefundene Ziele: ${foundCount}\nZeit: ${Math.floor((Date.now()-timerStart)/1000)} s`); }
+    if (foundCount>=initialTargets) {
+      clearInterval(timerInterval);
+      const msg = `Spiel beendet!\nGefundene Ziele: ${foundCount}\nZeit: ${Math.floor((Date.now()-timerStart)/1000)} s`;
+      setTimeout(() => {
+        alert(msg);
+        resetToOriginalGrid();
+      }, 50);
+    }
   } else { playPowSound(); }
+}
+
+function resetToOriginalGrid() {
+  gameGrid = originalGrid.map(r=>r.slice());
+  const w = worldData[currentWorld];
+  initialTargets = gameGrid.flat().filter(c => c === w.target).length;
+  foundCount = 0;
+  timerStart = null;
+  playerX = 0; playerY = 0;
+  gameGrid.forEach((row, ry) => row.forEach((c, cx) => {
+    if (c === w.player) { playerX = cx; playerY = ry; }
+  }));
+  document.getElementById('foundCount').innerText = 'Gefundene Ziele: 0';
+  document.getElementById('timerDisplay').innerText = 'Zeit: 0 s';
+  renderGame();
 }
 
 // Spiel-Buttons


### PR DESCRIPTION
## Summary
- restore the game grid to the original layout when the round ends
- added helper `resetToOriginalGrid` and call it after the alert

## Testing
- `npm test` *(fails: Could not read package.json)*